### PR TITLE
Refactor to tidy up conditional answers across sections

### DIFF
--- a/app/common/controllers/saveAndContinue.utils.ts
+++ b/app/common/controllers/saveAndContinue.utils.ts
@@ -51,7 +51,7 @@ export type FormErrors = { [code: string]: string }
 type Node = { code: string; dependents?: Node[] }
 
 export const compileConditionalFields = (fields: FormWizard.Field[], errors: FormErrors) => {
-  const fieldsWithDependencies = fields.filter(field => field.dependent)
+  const fieldsWithDependencies = fields.filter(field => field.dependent && field.dependent.displayInline)
   const fieldCodes = fieldsWithDependencies.map(field => field.code)
 
   const rootFieldsWithDependencies = fieldsWithDependencies

--- a/app/common/utils/forms/formRouterBuilder.ts
+++ b/app/common/utils/forms/formRouterBuilder.ts
@@ -24,7 +24,7 @@ const setupForm = (form: Form, options: BaseFormOptions): FormWizardRouter => {
         .map(([path, stepConfig]) => ({ url: `${req.baseUrl}${path}`, label: stepConfig.pageTitle }))
 
       res.locals.form = {
-        fields: fields.filter(fieldCode => !form.fields[fieldCode].dependent),
+        fields: fields.filter(fieldCode => !form.fields[fieldCode]?.dependent?.displayInline),
         navigation: steps,
       }
 

--- a/app/sbna-poc/v1_0__initial-form/fields.ts
+++ b/app/sbna-poc/v1_0__initial-form/fields.ts
@@ -52,6 +52,10 @@ const fields: FormWizard.Fields = {
     code: 'no_accommodation_details',
     type: FieldType.TextArea,
     validate: [{ type: ValidationType.Required, message: 'Field is required' }],
+    dependent: {
+      field: 'current_accommodation',
+      value: 'NO_ACCOMMODATION',
+    },
   },
   suitable_housing_details: {
     text: "What's helped [subject] stay in suitable housing in the past?",
@@ -79,6 +83,7 @@ const fields: FormWizard.Fields = {
     dependent: {
       field: 'suitable_housing_planned',
       value: 'AWAITING_PLACEMENT',
+      displayInline: true,
     },
   },
   accommodation_changes: {

--- a/server/@types/hmpo-form-wizard/index.d.ts
+++ b/server/@types/hmpo-form-wizard/index.d.ts
@@ -127,7 +127,7 @@ declare module 'hmpo-form-wizard' {
       | { type: ValidationType; arguments?: (string | number)[]; message: string }
       | { fn: ValidatorFn; arguments?: (string | number)[]; message: string }
 
-    type Dependent = { field: string; value: string }
+    type Dependent = { field: string; value: string; displayInline?: boolean }
 
     interface Field {
       default?: string | number | []


### PR DESCRIPTION
I've added the flag `displayInline` to conditional questions, fields with this set to true will be pre-rendered alongside the triggering question. All fields with dependencies will have their answers removed in the backend when their condition is no longer met