### PR TITLE
Refactor how answers are handled in saveAndContinueController

### DIFF
--- a/app/common/controllers/saveAndContinue.ts
+++ b/app/common/controllers/saveAndContinue.ts
@@ -38,8 +38,6 @@ class SaveAndContinueController extends BaseController {
       })
       .reduce((updatedAnswers, [key, field]) => ({ ...updatedAnswers, [field.code]: req.form.values[key] }), {})
 
-    req.form.submittedAnswers = req.form.values
-
     return super.process(req, res, next)
   }
 
@@ -51,7 +49,6 @@ class SaveAndContinueController extends BaseController {
     const fieldsWithRenderedConditionals = compileConditionalFields(fieldsWithReplacements, {
       action: res.locals.action,
       errors: res.locals.errors,
-      collections: res.locals.collections,
     })
 
     res.locals.answers = req.form.values

--- a/app/common/controllers/saveAndContinue.utils.ts
+++ b/app/common/controllers/saveAndContinue.utils.ts
@@ -5,7 +5,6 @@ export const formatForNunjucks = (str = '') => str.split('}').join('} ').trim() 
 
 interface Locals {
   errors: unknown
-  collections: unknown
   action: string
 }
 
@@ -13,7 +12,7 @@ const renderConditionalQuestion = (
   allFields: FormWizard.Field[],
   thisField: FormWizard.Field,
   dependentFieldNodes: Node[],
-  locals: Locals = { errors: {}, collections: {}, action: '/' },
+  locals: Locals = { errors: {}, action: '/' },
   _nunjucks = nunjucks,
 ): FormWizard.Field => {
   const conditionalFields = dependentFieldNodes.map(({ id, dependents }) => {
@@ -42,11 +41,10 @@ const renderConditionalQuestion = (
 
       const fieldString = formatForNunjucks(JSON.stringify(field))
       const errorString = formatForNunjucks(JSON.stringify(locals.errors))
-      const collectionsString = formatForNunjucks(JSON.stringify(locals.collections))
 
       const template =
         '{% from "components/question/macro.njk" import renderQuestion %} \n' +
-        `{{ renderQuestion(${fieldString}, ${errorString}, ${collectionsString}, "${locals.action}") }}`
+        `{{ renderQuestion(${fieldString}, ${errorString}, "${locals.action}") }}`
 
       const renderedHtml = _nunjucks.renderString(template, {}).replace(/(\r\n|\n|\r)\s+/gm, '')
 

--- a/app/sbna-poc/v1_0__initial-form/controllers/saveAndContinueController.test.ts
+++ b/app/sbna-poc/v1_0__initial-form/controllers/saveAndContinueController.test.ts
@@ -79,7 +79,7 @@ describe('SaveAndContinueController', () => {
       expect(conditionFn).toHaveBeenLastCalledWith(true, formValues)
     })
 
-    it('includes the returned value of conditionFn of each field in submittedValues', () => {
+    it('includes the returned value of conditionFn of each field in submittedAnswers', () => {
       const req = buildRequestWith({
         sectionProgressRules: [
           { fieldCode: 'foo_section_complete', conditionFn: () => 'FOO' },
@@ -90,7 +90,7 @@ describe('SaveAndContinueController', () => {
 
       controller.setSectionProgress(req)
 
-      expect(req.form.submittedAnswers).toEqual({
+      expect(req.form.values).toEqual({
         foo_section_complete: 'FOO',
         bar_section_complete: 'BAR',
         baz_section_complete: 'BAZ',

--- a/app/sbna-poc/v1_0__initial-form/controllers/saveAndContinueController.utils.test.ts
+++ b/app/sbna-poc/v1_0__initial-form/controllers/saveAndContinueController.utils.test.ts
@@ -24,20 +24,12 @@ describe('sbna-poc/controllers/saveAndContinueController.utils', () => {
   })
 
   describe('mergeAnswers', () => {
-    it('transforms persisted answers in to simple key/value pairs', () => {
-      const persistedAnswers: Record<string, AnswerDto> = {
-        single_value_field: { description: 'Single value field', type: FieldType.Text, value: 'FOO' },
-        single_value_field_2: { description: 'Single value field', type: FieldType.Text, value: 'not updated' },
-        multiple_value_field: {
-          description: 'Multiple value field',
-          type: FieldType.CheckBox,
-          values: ['FOO', 'BAR', 'BAZ'],
-        },
-        multiple_value_field_2: {
-          description: 'Multiple value field',
-          type: FieldType.CheckBox,
-          values: ['NOT_UPDATED'],
-        },
+    it('applies submitted answers over persisted answers', () => {
+      const persistedAnswers: Record<string, string | string[]> = {
+        single_value_field: 'FOO',
+        single_value_field_2: 'not updated',
+        multiple_value_field: ['FOO', 'BAR', 'BAZ'],
+        multiple_value_field_2: ['NOT_UPDATED'],
       }
 
       const submittedAnswers: Record<string, string | string[]> = {

--- a/app/sbna-poc/v1_0__initial-form/controllers/saveAndContinueController.utils.ts
+++ b/app/sbna-poc/v1_0__initial-form/controllers/saveAndContinueController.utils.ts
@@ -23,9 +23,9 @@ export const buildRequestBody = (
   }
 }
 
-export const mergeAnswers = (persistedAnswers: Answers, submittedAnswers: SubmittedAnswers) => {
+export const mergeAnswers = (persistedAnswers: SubmittedAnswers, submittedAnswers: SubmittedAnswers) => {
   return {
-    ...flattenAnswers(persistedAnswers),
+    ...persistedAnswers,
     ...submittedAnswers,
   }
 }

--- a/app/sbna-poc/v1_0__initial-form/fields/drugs.test.ts
+++ b/app/sbna-poc/v1_0__initial-form/fields/drugs.test.ts
@@ -17,25 +17,25 @@ describe('sbna-poc/fields/drugs', () => {
     it('is valid when a value is present and the condition is met', () => {
       const validate = requiredWhenContains('foo', 'BAR')
 
-      expect(validate.bind(contextWithAnswers({ foo: { values: ['BAR'] } }))('baz')).toEqual(true)
+      expect(validate.bind(contextWithAnswers({ foo: ['BAR'] }))('baz')).toEqual(true)
     })
 
     it('is invalid when a value is not present and the condition is met', () => {
       const validate = requiredWhenContains('foo', 'BAR')
 
-      expect(validate.bind(contextWithAnswers({ foo: { values: ['BAR'] } }))('')).toEqual(false)
+      expect(validate.bind(contextWithAnswers({ foo: ['BAR'] }))('')).toEqual(false)
     })
 
     it('is valid when a value is present and the condition is not met', () => {
       const validate = requiredWhenContains('foo', 'BAR')
 
-      expect(validate.bind(contextWithAnswers({ foo: { values: [] } }))('baz')).toEqual(true)
+      expect(validate.bind(contextWithAnswers({ foo: [] }))('baz')).toEqual(true)
     })
 
     it('is valid when no value is present and the condition is not met', () => {
       const validate = requiredWhenContains('foo', 'BAR')
 
-      expect(validate.bind(contextWithAnswers({ foo: { values: [] } }))('')).toEqual(true)
+      expect(validate.bind(contextWithAnswers({ foo: [] }))('')).toEqual(true)
     })
   })
 })

--- a/app/sbna-poc/v1_0__initial-form/fields/drugs.ts
+++ b/app/sbna-poc/v1_0__initial-form/fields/drugs.ts
@@ -19,7 +19,7 @@ const usageFrequencies = [
 export function requiredWhenContains(field: string, requiredValue: string) {
   return function validateRequiredWhenContains(value: string) {
     const persistedAnswers = this.sessionModel?.options?.req?.form?.persistedAnswers || {}
-    const values = persistedAnswers[field]?.values
+    const values = persistedAnswers[field]
 
     return (
       Array.isArray(values) && (!values.includes(requiredValue) || (values.includes(requiredValue) && value !== ''))

--- a/server/@types/hmpo-form-wizard/index.d.ts
+++ b/server/@types/hmpo-form-wizard/index.d.ts
@@ -81,7 +81,7 @@ declare module 'hmpo-form-wizard' {
 
     interface Request extends express.Request {
       form: {
-        values: { [key: string]: string | string[] }
+        values: Record<string, string | string[]>
         options: {
           allFields: { [key: string]: Field }
           journeyName: string
@@ -89,8 +89,7 @@ declare module 'hmpo-form-wizard' {
           sectionProgressRules: Array<SectionProgressRule>
           fields: Fields
         }
-        persistedAnswers: { [key: string]: AnswerDto }
-        submittedAnswers: Record<string, string | string[]>
+        persistedAnswers: Record<string, string | string[]>
       }
       sessionModel: {
         set: (key: string, value: unknown) => void

--- a/server/views/components/question/macro.njk
+++ b/server/views/components/question/macro.njk
@@ -1,3 +1,3 @@
-{% macro renderQuestion(question, errors, collections, action) %}
+{% macro renderQuestion(question, errors, action) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/server/views/forms/default.njk
+++ b/server/views/forms/default.njk
@@ -29,7 +29,7 @@
         classes: fieldPrototype.classes
       } %}
 
-      {{ renderQuestion(fieldOptions, errors, collections, action) }}
+      {{ renderQuestion(fieldOptions, errors, action) }}
     {% endfor %}
 
     <div class="questiongroup-action-buttons">


### PR DESCRIPTION
- Remove `submittedAnswers` in favour of using `req.form.values`
- Remove references to collections