### PR TITLE
Add support for tagging assessment data

### DIFF
--- a/app/oastub/v1_0__initial-form/controllers/oneTimeLinkController.ts
+++ b/app/oastub/v1_0__initial-form/controllers/oneTimeLinkController.ts
@@ -18,7 +18,7 @@ class OneTimeLinkController extends BaseController {
       const { link } = await this.apiService.createSession({
         userSessionId: 'ABC1234567890',
         userAccess: 'READ_WRITE',
-        oasysAssessmentId: randomUUID(),
+        oasysAssessmentPk: randomUUID(),
         userDisplayName: 'Probation User',
         crn: 'X123456',
       })

--- a/app/oastub/v1_0__initial-form/controllers/startController.ts
+++ b/app/oastub/v1_0__initial-form/controllers/startController.ts
@@ -18,7 +18,7 @@ class StartController extends BaseController {
       const { link } = await this.apiService.createSession({
         userSessionId: 'ABC1234567890',
         userAccess: 'READ_WRITE',
-        oasysAssessmentId: randomUUID(),
+        oasysAssessmentPk: randomUUID(),
         userDisplayName: 'Probation User',
         crn: 'X123456',
       })

--- a/server/services/strengthsBasedNeedsService.ts
+++ b/server/services/strengthsBasedNeedsService.ts
@@ -7,7 +7,7 @@ import getHmppsAuthClient from '../data/hmppsAuthClient'
 export interface CreateSessionRequest extends Record<string, unknown> {
   userSessionId: string
   userAccess: string
-  oasysAssessmentId: string
+  oasysAssessmentPk: string
 }
 
 export interface CreateSessionResponse {
@@ -58,6 +58,7 @@ export type Answers = Record<string, AnswerDto>
 export interface UpdateAnswersDto extends Record<string, unknown> {
   answersToAdd: Answers
   answersToRemove: string[]
+  tags?: string[]
 }
 
 export interface UpdateAnswersInCollectionDto extends Record<string, unknown> {
@@ -108,9 +109,9 @@ export default class StrengthsBasedNeedsAssessmentsApiService {
     return { firstName: 'Paul' }
   }
 
-  async fetchAnswers(assessmentUuid: string): Promise<Answers> {
+  async fetchAnswers(assessmentUuid: string, tag: string = 'unvalidated'): Promise<Answers> {
     const client = await this.getRestClient()
-    const responseBody = await client.get({ path: `/assessment/${assessmentUuid}/answers` })
+    const responseBody = await client.get({ path: `/assessment/${assessmentUuid}/version/${tag}/answers` })
     return responseBody as Answers
   }
 

--- a/server/views/forms/sbna-poc/accommodation-summary-analysis.njk
+++ b/server/views/forms/sbna-poc/accommodation-summary-analysis.njk
@@ -8,23 +8,26 @@
 {% endblock %}
 
 {% block analysisPanel %}
-  {% for field in (form.fields | removeSectionCompleteFields) %}
-    {{ renderQuestion(options.fields[field], errors) }}
-  {% endfor %}
+  <form id="form" method="post" action="{{ action }}#practitioner-analysis">
+    <input type="hidden" name="x-csrf-token" value="{{ getCsrf() }}">
+    {% for field in (form.fields | removeSectionCompleteFields) %}
+      {{ renderQuestion(options.fields[field], errors) }}
+    {% endfor %}
 
-  <div class="questiongroup-action-buttons">
-    {{ govukButton({
-      text: buttonText | default("Mark as complete"),
-      classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
-    }) }}
+    <div class="questiongroup-action-buttons">
+      {{ govukButton({
+        text: buttonText | default("Mark as complete"),
+        classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
+      }) }}
 
-    {% set saveDraftAction = action + "?action=saveDraft" %}
-    {{ govukButton({
-      text: "Save as draft",
-      classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
-      attributes: {
-        "formaction": saveDraftAction
-      }
-    }) }}
-  </div>
+      {% set saveDraftAction = action + "?action=saveDraft" %}
+      {{ govukButton({
+        text: "Save as draft",
+        classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
+        attributes: {
+          "formaction": saveDraftAction
+        }
+      }) }}
+    </div>
+  </form>
 {% endblock %}

--- a/server/views/forms/sbna-poc/alcohol-summary-analysis.njk
+++ b/server/views/forms/sbna-poc/alcohol-summary-analysis.njk
@@ -8,23 +8,26 @@
 {% endblock %}
 
 {% block analysisPanel %}
-  {% for field in (form.fields | removeSectionCompleteFields) %}
-    {{ renderQuestion(options.fields[field], errors) }}
-  {% endfor %}
+  <form id="form" method="post" action="{{ action }}#practitioner-analysis">
+    <input type="hidden" name="x-csrf-token" value="{{ getCsrf() }}">
+    {% for field in (form.fields | removeSectionCompleteFields) %}
+      {{ renderQuestion(options.fields[field], errors) }}
+    {% endfor %}
 
-  <div class="questiongroup-action-buttons">
-    {{ govukButton({
-      text: buttonText | default("Mark as complete"),
-      classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
-    }) }}
+    <div class="questiongroup-action-buttons">
+      {{ govukButton({
+        text: buttonText | default("Mark as complete"),
+        classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
+      }) }}
 
-    {% set saveDraftAction = action + "?action=saveDraft" %}
-    {{ govukButton({
-      text: "Save as draft",
-      classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
-      attributes: {
-        "formaction": saveDraftAction
-      }
-    }) }}
-  </div>
+      {% set saveDraftAction = action + "?action=saveDraft" %}
+      {{ govukButton({
+        text: "Save as draft",
+        classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
+        attributes: {
+          "formaction": saveDraftAction
+        }
+      }) }}
+    </div>
+  </form>
 {% endblock %}

--- a/server/views/forms/sbna-poc/drugs-summary-analysis.njk
+++ b/server/views/forms/sbna-poc/drugs-summary-analysis.njk
@@ -8,23 +8,26 @@
 {% endblock %}
 
 {% block analysisPanel %}
-  {% for field in (form.fields | removeSectionCompleteFields) %}
-    {{ renderQuestion(options.fields[field], errors) }}
-  {% endfor %}
+  <form id="form" method="post" action="{{ action }}#practitioner-analysis">
+    <input type="hidden" name="x-csrf-token" value="{{ getCsrf() }}">
+    {% for field in (form.fields | removeSectionCompleteFields) %}
+      {{ renderQuestion(options.fields[field], errors) }}
+    {% endfor %}
 
-  <div class="questiongroup-action-buttons">
-    {{ govukButton({
-      text: buttonText | default("Mark as complete"),
-      classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
-    }) }}
+    <div class="questiongroup-action-buttons">
+      {{ govukButton({
+        text: buttonText | default("Mark as complete"),
+        classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
+      }) }}
 
-    {% set saveDraftAction = action + "?action=saveDraft" %}
-    {{ govukButton({
-      text: "Save as draft",
-      classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
-      attributes: {
-        "formaction": saveDraftAction
-      }
-    }) }}
-  </div>
+      {% set saveDraftAction = action + "?action=saveDraft" %}
+      {{ govukButton({
+        text: "Save as draft",
+        classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
+        attributes: {
+          "formaction": saveDraftAction
+        }
+      }) }}
+    </div>
+  </form>
 {% endblock %}

--- a/server/views/forms/sbna-poc/employment-education-summary-analysis.njk
+++ b/server/views/forms/sbna-poc/employment-education-summary-analysis.njk
@@ -8,23 +8,26 @@
 {% endblock %}
 
 {% block analysisPanel %}
-  {% for field in (form.fields | removeSectionCompleteFields) %}
-    {{ renderQuestion(options.fields[field], errors) }}
-  {% endfor %}
+  <form id="form" method="post" action="{{ action }}#practitioner-analysis">
+    <input type="hidden" name="x-csrf-token" value="{{ getCsrf() }}">
+    {% for field in (form.fields | removeSectionCompleteFields) %}
+      {{ renderQuestion(options.fields[field], errors) }}
+    {% endfor %}
 
-  <div class="questiongroup-action-buttons">
-    {{ govukButton({
-      text: buttonText | default("Mark as complete"),
-      classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
-    }) }}
+    <div class="questiongroup-action-buttons">
+      {{ govukButton({
+        text: buttonText | default("Mark as complete"),
+        classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
+      }) }}
 
-    {% set saveDraftAction = action + "?action=saveDraft" %}
-    {{ govukButton({
-      text: "Save as draft",
-      classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
-      attributes: {
-        "formaction": saveDraftAction
-      }
-    }) }}
-  </div>
+      {% set saveDraftAction = action + "?action=saveDraft" %}
+      {{ govukButton({
+        text: "Save as draft",
+        classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
+        attributes: {
+          "formaction": saveDraftAction
+        }
+      }) }}
+    </div>
+  </form>
 {% endblock %}

--- a/server/views/forms/sbna-poc/finance-summary-analysis.njk
+++ b/server/views/forms/sbna-poc/finance-summary-analysis.njk
@@ -8,23 +8,26 @@
 {% endblock %}
 
 {% block analysisPanel %}
-  {% for field in (form.fields | removeSectionCompleteFields) %}
-    {{ renderQuestion(options.fields[field], errors) }}
-  {% endfor %}
+  <form id="form" method="post" action="{{ action }}#practitioner-analysis">
+    <input type="hidden" name="x-csrf-token" value="{{ getCsrf() }}">
+    {% for field in (form.fields | removeSectionCompleteFields) %}
+      {{ renderQuestion(options.fields[field], errors) }}
+    {% endfor %}
 
-  <div class="questiongroup-action-buttons">
-    {{ govukButton({
-      text: buttonText | default("Mark as complete"),
-      classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
-    }) }}
+    <div class="questiongroup-action-buttons">
+      {{ govukButton({
+        text: buttonText | default("Mark as complete"),
+        classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
+      }) }}
 
-    {% set saveDraftAction = action + "?action=saveDraft" %}
-    {{ govukButton({
-      text: "Save as draft",
-      classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
-      attributes: {
-        "formaction": saveDraftAction
-      }
-    }) }}
-  </div>
+      {% set saveDraftAction = action + "?action=saveDraft" %}
+      {{ govukButton({
+        text: "Save as draft",
+        classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
+        attributes: {
+          "formaction": saveDraftAction
+        }
+      }) }}
+    </div>
+  </form>
 {% endblock %}

--- a/server/views/forms/sbna-poc/health-wellbeing-summary-analysis.njk
+++ b/server/views/forms/sbna-poc/health-wellbeing-summary-analysis.njk
@@ -8,23 +8,26 @@
 {% endblock %}
 
 {% block analysisPanel %}
-  {% for field in (form.fields | removeSectionCompleteFields) %}
-    {{ renderQuestion(options.fields[field], errors) }}
-  {% endfor %}
+  <form id="form" method="post" action="{{ action }}#practitioner-analysis">
+    <input type="hidden" name="x-csrf-token" value="{{ getCsrf() }}">
+    {% for field in (form.fields | removeSectionCompleteFields) %}
+      {{ renderQuestion(options.fields[field], errors) }}
+    {% endfor %}
 
-  <div class="questiongroup-action-buttons">
-    {{ govukButton({
-      text: buttonText | default("Mark as complete"),
-      classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
-    }) }}
+    <div class="questiongroup-action-buttons">
+      {{ govukButton({
+        text: buttonText | default("Mark as complete"),
+        classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
+      }) }}
 
-    {% set saveDraftAction = action + "?action=saveDraft" %}
-    {{ govukButton({
-      text: "Save as draft",
-      classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
-      attributes: {
-        "formaction": saveDraftAction
-      }
-    }) }}
-  </div>
+      {% set saveDraftAction = action + "?action=saveDraft" %}
+      {{ govukButton({
+        text: "Save as draft",
+        classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
+        attributes: {
+          "formaction": saveDraftAction
+        }
+      }) }}
+    </div>
+  </form>
 {% endblock %}

--- a/server/views/forms/summary.njk
+++ b/server/views/forms/summary.njk
@@ -34,10 +34,7 @@
   </div>
   <div class="govuk-tabs__panel summary__panel govuk-tabs__panel--hidden" id="practitioner-analysis">
     <div class="govuk-!-width-three-quarters">
-      <form id="form" method="post" action="{{ action }}#practitioner-analysis">
-        <input type="hidden" name="x-csrf-token" value="{{ getCsrf() }}">
-        {% block analysisPanel %}{% endblock %}
-      </form>
+      {% block analysisPanel %}{% endblock %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
- Update SaveAndContinue controller to support tagging of assessment data
- Update endpoints to reflect changes to the API
- Fix a bug affecting assessment progress with autosave
- Fix a bug that prevented assessments from being resumed correctly
- Update autosave to only save when changes have been made