### PR TITLE
Arn 1795 tba summary page

### DIFF
--- a/app/sbna-poc/v1_0__initial-form/fields/thinking-behaviours-attitudes.ts
+++ b/app/sbna-poc/v1_0__initial-form/fields/thinking-behaviours-attitudes.ts
@@ -488,8 +488,9 @@ export const makeChangesFields: Array<FormWizard.Field> = [
   ...makeChangesOptionsWithDetails.map(detailsFieldWith('thinking_behaviours_attitudes_changes')),
 ]
 
-export const practitionerAnalysisFields: Array<FormWizard.Field> =
-  createPractitionerAnalysisFieldsWith('health_wellbeing')
+export const practitionerAnalysisFields: Array<FormWizard.Field> = createPractitionerAnalysisFieldsWith(
+  'thinking-behaviours-attitudes',
+)
 
 export const questionSectionComplete: FormWizard.Field = {
   text: 'Is the thinking behaviours and attitude section complete?',

--- a/app/sbna-poc/v1_0__initial-form/fields/thinking-behaviours-attitudes.ts
+++ b/app/sbna-poc/v1_0__initial-form/fields/thinking-behaviours-attitudes.ts
@@ -50,7 +50,7 @@ export const thinkingBehavioursAttitudesFields: Array<FormWizard.Field> = [
     labelClasses: getMediumLabelClassFor(FieldType.Radio),
   },
   {
-    text: 'Does [subject] engage in activities that could link to offending??',
+    text: 'Does [subject] engage in activities that could link to offending?',
     code: 'thinking_behaviours_attitudes_offending_activities',
     type: FieldType.Radio,
     validate: [
@@ -196,7 +196,7 @@ export const riskOfSexualHarmFields: Array<FormWizard.Field> = [
   },
   {
     text: 'Does [subject] show evidence of offence-related sexual interests?',
-    code: 'thinking_behaviours_attitudes_offence-related-sexual-interest',
+    code: 'thinking_behaviours_attitudes_offence_related_sexual_interest',
     type: FieldType.Radio,
     validate: [
       { type: ValidationType.Required, message: 'Select if they show evidence of offence-related sexual interests' },

--- a/app/sbna-poc/v1_0__initial-form/steps/thinking-behaviour-attitudes.ts
+++ b/app/sbna-poc/v1_0__initial-form/steps/thinking-behaviour-attitudes.ts
@@ -46,7 +46,7 @@ const stepOptions: FormWizard.Steps = {
   '/thinking-behaviours': {
     pageTitle: defaultTitle,
     fields: fieldCodesFrom(thinkingBehaviourFields, makeChangesFields, sectionCompleteFields),
-    next: '',
+    next: 'thinking-behaviours-attitudes-summary-analysis',
     backLink: 'thinking-behaviours-attitudes',
     section: sectionName,
     sectionProgressRules: [
@@ -57,8 +57,8 @@ const stepOptions: FormWizard.Steps = {
   '/thinking-behaviours-attitudes-summary-analysis': {
     pageTitle: defaultTitle,
     fields: fieldCodesFrom(practitionerAnalysisFields, [analysisSectionComplete]),
-    next: '',
-    template: '',
+    next: 'thinking-behaviours-attitudes-analysis-complete#practitioner-analysis',
+    template: 'forms/sbna-poc/thinking-behaviours-attitudes-summary-analysis',
     section: sectionName,
     sectionProgressRules: [setFieldWhenValid('', 'YES', 'NO')],
   },
@@ -66,7 +66,7 @@ const stepOptions: FormWizard.Steps = {
     pageTitle: defaultTitle,
     fields: [],
     next: [],
-    template: '',
+    template: 'forms/sbna-poc/thinking-behaviours-attitudes-summary-analysis-complete',
     section: sectionName,
   },
 }

--- a/app/sbna-poc/v1_0__initial-form/steps/thinking-behaviour-attitudes.ts
+++ b/app/sbna-poc/v1_0__initial-form/steps/thinking-behaviour-attitudes.ts
@@ -28,8 +28,8 @@ const stepOptions: FormWizard.Steps = {
     ].flat(),
     section: sectionName,
     sectionProgressRules: [
-      setField('thinking-behaviours-attitudes_section_complete', 'NO'),
-      setField('thinking-behaviours-attitudes_analysis_section_complete', 'NO'),
+      setField('thinking_behaviours_attitudes_section_complete', 'NO'),
+      setField('thinking_behaviours_attitudes_analysis_section_complete', 'NO'),
     ],
   },
   '/thinking-behaviours-attitudes-sexual-offending': {
@@ -50,8 +50,8 @@ const stepOptions: FormWizard.Steps = {
     backLink: 'thinking-behaviours-attitudes',
     section: sectionName,
     sectionProgressRules: [
-      setField('thinking-behaviours-attitudes_section_complete', 'NO'),
-      setField('thinking-behaviours-attitudes_analysis_section_complete', 'NO'),
+      setField('thinking_behaviours_attitudes_section_complete', 'NO'),
+      setField('thinking_behaviours_attitudes_analysis_section_complete', 'NO'),
     ],
   },
   '/thinking-behaviours-attitudes-summary-analysis': {
@@ -60,7 +60,7 @@ const stepOptions: FormWizard.Steps = {
     next: 'thinking-behaviours-attitudes-analysis-complete#practitioner-analysis',
     template: 'forms/sbna-poc/thinking-behaviours-attitudes-summary-analysis',
     section: sectionName,
-    sectionProgressRules: [setFieldWhenValid('', 'YES', 'NO')],
+    sectionProgressRules: [setFieldWhenValid('thinking_behaviours_attitudes_section_complete', 'YES', 'NO')],
   },
   '/thinking-behaviours-attitudes-analysis-complete': {
     pageTitle: defaultTitle,

--- a/server/views/components/summary/health-wellbeing/template.njk
+++ b/server/views/components/summary/health-wellbeing/template.njk
@@ -1,4 +1,30 @@
-{% from "components/summary/macro.njk" import renderSummaryListRow %}
+{%- macro renderSelectedOptions(field) -%}
+  <ul class="govuk-list">
+    {% for option in field.options %}
+      {% if option.checked %}
+        <li class="summary-details-list">
+          <span class="summary__answer">{{ option.text }}</span>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{%- endmacro -%}
+
+{%- macro renderSummaryListRow(label, value, changeLink) -%}
+  <div class="govuk-summary-list__row as-block clearfix">
+    <dt class="govuk-summary-list__key to-the-left">
+      <span class="summary__label">{{ label }}</span>
+    </dt>
+    <dd class="govuk-summary-list__value to-the-left summary-value">
+      {{ value }}
+    </dd>
+    <dd class="govuk-summary-list__actions to-the-right">
+      <a class="govuk-link" href="{{ changeLink }}">
+      Change<span class="govuk-visually-hidden">value for {{ label }}</span>
+      </a>
+    </dd>
+  </div>
+{%- endmacro -%}
 
 {%- macro renderSubOption(field) -%}
     {% for option in field.options %}

--- a/server/views/components/summary/health-wellbeing/template.njk
+++ b/server/views/components/summary/health-wellbeing/template.njk
@@ -1,14 +1,4 @@
-{%- macro renderSelectedOptions(field) -%}
-  <ul class="govuk-list">
-    {% for option in field.options %}
-      {% if option.checked %}
-        <li class="summary-details-list">
-          <span class="summary__answer">{{ option.text }}</span>
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ul>
-{%- endmacro -%}
+{% from "components/summary/macro.njk" import renderSummaryListRow %}
 
 {%- macro renderSubOption(field) -%}
     {% for option in field.options %}
@@ -16,22 +6,6 @@
         <span class="summary__answer--secondary">{{ option.text }}</span>
       {% endif %}
     {% endfor %}
-{%- endmacro -%}
-
-{%- macro renderSummaryListRow(label, value, changeLink) -%}
-  <div class="govuk-summary-list__row as-block clearfix">
-    <dt class="govuk-summary-list__key to-the-left">
-      <span class="summary__label">{{ label }}</span>
-    </dt>
-    <dd class="govuk-summary-list__value to-the-left summary-value">
-      {{ value }}
-    </dd>
-    <dd class="govuk-summary-list__actions to-the-right">
-      <a class="govuk-link" href="{{ changeLink }}">
-      Change<span class="govuk-visually-hidden">value for {{ label }}</span>
-      </a>
-    </dd>
-  </div>
 {%- endmacro -%}
 
 {%- macro renderPhysicalHealthCondition(fields, answers) -%}

--- a/server/views/components/summary/macro.njk
+++ b/server/views/components/summary/macro.njk
@@ -1,0 +1,31 @@
+{%- macro renderListRow(label, value, changeLink) -%}
+  <div class="govuk-summary-list__row as-block clearfix">
+    <dt class="govuk-summary-list__key to-the-left">
+      <span class="summary__label">{{ label }}</span>
+    </dt>
+    <dd class="govuk-summary-list__value to-the-left summary-value">
+      {{ value }}
+    </dd>
+    <dd class="govuk-summary-list__actions to-the-right">
+      <a class="govuk-link" href="{{ changeLink }}">
+        Change<span class="govuk-visually-hidden">value for {{ label }}</span>
+      </a>
+    </dd>
+  </div>
+{%- endmacro -%}
+
+{%- macro renderSelectedOptions(field, answers) -%}
+  <ul class="govuk-list">
+    {% for option in field.options %}
+      {% if option.checked %}
+        <li class="summary-details-list">
+          <span class="summary__answer">{{ option.text }}</span>
+          {% set detailsFieldCode = (field.code + "_" + option.value + "_details") | lower %}
+          {% if detailsFieldCode in answers %}
+            <span class="govuk-!-font-size-16">{{ answers[detailsFieldCode] }}</span>
+          {% endif %}
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{%- endmacro -%}

--- a/server/views/components/summary/thinking-behaviours-attitudes/macro.njk
+++ b/server/views/components/summary/thinking-behaviours-attitudes/macro.njk
@@ -1,0 +1,3 @@
+{% macro renderSummaryFor(fields, answers) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/server/views/components/summary/thinking-behaviours-attitudes/template.njk
+++ b/server/views/components/summary/thinking-behaviours-attitudes/template.njk
@@ -1,103 +1,60 @@
-{%- macro renderSelectedOptions(field) -%}
-  <ul class="govuk-list">
-    {% for option in field.options %}
-      {% if option.checked %}
-        <li class="summary-details-list">
-          <span class="summary__answer">{{ option.text }}</span>
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ul>
-{%- endmacro -%}
-
-{%- macro renderSubOption(field) -%}
-    {% for option in field.options %}
-      {% if option.checked %}
-        <span class="summary__answer--secondary">{{ option.text }}</span>
-      {% endif %}
-    {% endfor %}
-{%- endmacro -%}
-
-{%- macro renderSummaryListRow(label, value, changeLink) -%}
-  <div class="govuk-summary-list__row as-block clearfix">
-    <dt class="govuk-summary-list__key to-the-left">
-      <span class="summary__label">{{ label }}</span>
-    </dt>
-    <dd class="govuk-summary-list__value to-the-left summary-value">
-      {{ value }}
-    </dd>
-    <dd class="govuk-summary-list__actions to-the-right">
-      <a class="govuk-link" href="{{ changeLink }}">
-      Change<span class="govuk-visually-hidden">value for {{ label }}</span>
-      </a>
-    </dd>
-  </div>
-{%- endmacro -%}
-
-{%- macro renderConsequences(fields, answers) -%}
-  <ul class="govuk-list">
-    {% for option in fields["thinking_behaviours_attitudes_consequences"].options %}
-        {% if option.checked %}
-        <li class="summary-details-list">
-           <span class="summary__answer">{{ option.text }}</span>
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ul>
-{%- endmacro -%}
-
-{%- macro renderStableBehaviour(fields, answers) -%}
-  <ul class="govuk-list">
-    {% for option in fields["thinking_behaviours_attitudes_stable_behaviour"].options %}
-        {% if option.checked %}
-        <li class="summary-details-list">
-           <span class="summary__answer">{{ option.text }}</span>
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ul>
-{%- endmacro -%}
-
-{%- macro renderOffendingActivities(fields, answers) -%}
-  <ul class="govuk-list">
-    {% for option in fields["thinking_behaviours_attitudes_offending_activities"].options %}
-        {% if option.checked %}
-        <li class="summary-details-list">
-           <span class="summary__answer">{{ option.text }}</span>
-        </li>
-      {% endif %}
-    {% endfor %}
-  </ul>
-{%- endmacro -%}
-
-
-{% macro renderSummaryItemFor(field, options) %}
-  {%- switch field -%}
-    {% case "thinking_behaviours_attitudes_consequences" %}
-      {{ renderSummaryListRow(
-        options.fields[field].text,
-        renderConsequences(options.fields, options.answers),
-        options.backLink + "#" + field
-      ) }}
-      {% case "thinking_behaviours_attitudes_stable_behaviour" %}
-      {{ renderSummaryListRow(
-        options.fields[field].text,
-        renderStableBehaviour(options.fields, options.answers),
-        options.backLink + "#" + field
-      ) }}
-      {% case "thinking_behaviours_attitudes_offending_activities" %}
-      {{ renderSummaryListRow(
-        options.fields[field].text,
-        renderOffendingActivities(options.fields, options.answers),
-        options.backLink + "#" + field
-      ) }}
-    
-    
-  {%- endswitch -%}
-{% endmacro %}
+{% import "components/summary/macro.njk" as summary %}
 
 <dl class="govuk-summary-list">
-  {{ renderSummaryItemFor("thinking_behaviours_attitudes_consequences", { fields: fields, answers: answers, backLink: "thinking-behaviours-attitudes" }) }}
-  {{ renderSummaryItemFor("thinking_behaviours_attitudes_stable_behaviour", { fields: fields, answers: answers, backLink: "thinking-behaviours-attitudes" }) }}
-  {{ renderSummaryItemFor("thinking_behaviours_attitudes_offending_activities", { fields: fields, answers: answers, backLink: "thinking-behaviours-attitudes" }) }}
+  {% set fieldCodes = [
+    "thinking_behaviours_attitudes_consequences",
+    "thinking_behaviours_attitudes_stable_behaviour",
+    "thinking_behaviours_attitudes_offending_activities",
+    "thinking_behaviours_attitudes_problem_solving",
+    "thinking_behaviours_attitudes_peoples_views",
+    "thinking_behaviours_attitudes_manipulative_predatory_behaviour",
+    "thinking_behaviours_attitudes_risk_sexual_harm"
+  ] %}
+
+  {% for fieldCode in fieldCodes %}
+    {{ summary.renderListRow(
+      fields[fieldCode].text,
+      summary.renderSelectedOptions(fields[fieldCode], answers),
+      "thinking-behaviours-attitudes#" + fieldCode
+    ) }}
+  {% endfor %}
+
+
+  {% if answers["thinking_behaviours_attitudes_risk_sexual_harm"] == "YES" %}
+
+    {% set fieldCodes = [
+      "thinking_behaviours_attitudes_sexual_preoccupation",
+      "thinking_behaviours_attitudes_offence_related_sexual_interest",
+      "thinking_behaviours_attitudes_emotional_compatibility"
+    ] %}
+
+    {% for fieldCode in fieldCodes %}
+      {{ summary.renderListRow(
+        fields[fieldCode].text,
+        summary.renderSelectedOptions(fields[fieldCode], answers),
+        "thinking-behaviours-attitudes-sexual-offending#" + fieldCode
+      ) }}
+    {% endfor %}
+
+  {% endif %}
+
+  {% set fieldCodes = [
+    "thinking_behaviours_attitudes_temper_management",
+    "thinking_behaviours_attitudes_violence_controlling_behaviour",
+    "thinking_behaviours_attitudes_impulsive_behaviour",
+    "thinking_behaviours_attitudes_positive_attitude",
+    "thinking_behaviours_attitudes_hostile_orientation",
+    "thinking_behaviours_attitudes_supervision",
+    "thinking_behaviours_attitudes_criminal_behaviour",
+    "thinking_behaviours_attitudes_changes"
+  ] %}
+
+  {% for fieldCode in fieldCodes %}
+    {{ summary.renderListRow(
+      fields[fieldCode].text,
+      summary.renderSelectedOptions(fields[fieldCode], answers),
+      "thinking-behaviours#" + fieldCode
+    ) }}
+  {% endfor %}
+
 </dl>

--- a/server/views/components/summary/thinking-behaviours-attitudes/template.njk
+++ b/server/views/components/summary/thinking-behaviours-attitudes/template.njk
@@ -1,0 +1,63 @@
+{%- macro renderSelectedOptions(field) -%}
+  <ul class="govuk-list">
+    {% for option in field.options %}
+      {% if option.checked %}
+        <li class="summary-details-list">
+          <span class="summary__answer">{{ option.text }}</span>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{%- endmacro -%}
+
+{%- macro renderSubOption(field) -%}
+    {% for option in field.options %}
+      {% if option.checked %}
+        <span class="summary__answer--secondary">{{ option.text }}</span>
+      {% endif %}
+    {% endfor %}
+{%- endmacro -%}
+
+{%- macro renderSummaryListRow(label, value, changeLink) -%}
+  <div class="govuk-summary-list__row as-block clearfix">
+    <dt class="govuk-summary-list__key to-the-left">
+      <span class="summary__label">{{ label }}</span>
+    </dt>
+    <dd class="govuk-summary-list__value to-the-left summary-value">
+      {{ value }}
+    </dd>
+    <dd class="govuk-summary-list__actions to-the-right">
+      <a class="govuk-link" href="{{ changeLink }}">
+      Change<span class="govuk-visually-hidden">value for {{ label }}</span>
+      </a>
+    </dd>
+  </div>
+{%- endmacro -%}
+
+{%- macro renderConsequences(fields, answers) -%}
+  <ul class="govuk-list">
+    {% for option in fields["thinking_behaviours_attitudes_consequences"].options %}
+        {% if option.checked %}
+        <li class="summary-details-list">
+           <span class="summary__answer">{{ option.text }}</span>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{%- endmacro -%}
+
+
+{% macro renderSummaryItemFor(field, options) %}
+  {%- switch field -%}
+    {% case "thinking_behaviours_attitudes_consequences" %}
+      {{ renderSummaryListRow(
+        options.fields[field].text,
+        renderConsequences(options.fields, options.answers),
+        options.backLink + "#" + field
+      ) }}
+  {%- endswitch -%}
+{% endmacro %}
+
+<dl class="govuk-summary-list">
+  {{ renderSummaryItemFor("thinking_behaviours_attitudes_consequences", { fields: fields, answers: answers, backLink: "thinking-behaviours-attitudes" }) }}
+</dl>

--- a/server/views/components/summary/thinking-behaviours-attitudes/template.njk
+++ b/server/views/components/summary/thinking-behaviours-attitudes/template.njk
@@ -1,5 +1,15 @@
 {% import "components/summary/macro.njk" as summary %}
 
+{%- macro renderRiskSexualHarmWarningText()-%}
+          <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-visually-hidden">Warning</span>
+              [subject] does not have any current or previous sexual or sexually motivated offences
+            </strong>
+          </div>
+{%- endmacro -%}
+
 <dl class="govuk-summary-list">
   {% set fieldCodes = [
     "thinking_behaviours_attitudes_consequences",
@@ -7,11 +17,23 @@
     "thinking_behaviours_attitudes_offending_activities",
     "thinking_behaviours_attitudes_problem_solving",
     "thinking_behaviours_attitudes_peoples_views",
-    "thinking_behaviours_attitudes_manipulative_predatory_behaviour",
+    "thinking_behaviours_attitudes_manipulative_predatory_behaviour"
+  ] %}
+
+  {% for fieldCode in fieldCodes %}
+    {{ summary.renderListRow(
+      fields[fieldCode].text,
+      summary.renderSelectedOptions(fields[fieldCode], answers),
+      "thinking-behaviours-attitudes#" + fieldCode
+    ) }}
+  {% endfor %}
+
+ {% set fieldCodes = [
     "thinking_behaviours_attitudes_risk_sexual_harm"
   ] %}
 
   {% for fieldCode in fieldCodes %}
+   {{ renderRiskSexualHarmWarningText() }}
     {{ summary.renderListRow(
       fields[fieldCode].text,
       summary.renderSelectedOptions(fields[fieldCode], answers),
@@ -56,5 +78,4 @@
       "thinking-behaviours#" + fieldCode
     ) }}
   {% endfor %}
-
 </dl>

--- a/server/views/components/summary/thinking-behaviours-attitudes/template.njk
+++ b/server/views/components/summary/thinking-behaviours-attitudes/template.njk
@@ -46,6 +46,30 @@
   </ul>
 {%- endmacro -%}
 
+{%- macro renderStableBehaviour(fields, answers) -%}
+  <ul class="govuk-list">
+    {% for option in fields["thinking_behaviours_attitudes_stable_behaviour"].options %}
+        {% if option.checked %}
+        <li class="summary-details-list">
+           <span class="summary__answer">{{ option.text }}</span>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{%- endmacro -%}
+
+{%- macro renderOffendingActivities(fields, answers) -%}
+  <ul class="govuk-list">
+    {% for option in fields["thinking_behaviours_attitudes_offending_activities"].options %}
+        {% if option.checked %}
+        <li class="summary-details-list">
+           <span class="summary__answer">{{ option.text }}</span>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+{%- endmacro -%}
+
 
 {% macro renderSummaryItemFor(field, options) %}
   {%- switch field -%}
@@ -55,9 +79,25 @@
         renderConsequences(options.fields, options.answers),
         options.backLink + "#" + field
       ) }}
+      {% case "thinking_behaviours_attitudes_stable_behaviour" %}
+      {{ renderSummaryListRow(
+        options.fields[field].text,
+        renderStableBehaviour(options.fields, options.answers),
+        options.backLink + "#" + field
+      ) }}
+      {% case "thinking_behaviours_attitudes_offending_activities" %}
+      {{ renderSummaryListRow(
+        options.fields[field].text,
+        renderOffendingActivities(options.fields, options.answers),
+        options.backLink + "#" + field
+      ) }}
+    
+    
   {%- endswitch -%}
 {% endmacro %}
 
 <dl class="govuk-summary-list">
   {{ renderSummaryItemFor("thinking_behaviours_attitudes_consequences", { fields: fields, answers: answers, backLink: "thinking-behaviours-attitudes" }) }}
+  {{ renderSummaryItemFor("thinking_behaviours_attitudes_stable_behaviour", { fields: fields, answers: answers, backLink: "thinking-behaviours-attitudes" }) }}
+  {{ renderSummaryItemFor("thinking_behaviours_attitudes_offending_activities", { fields: fields, answers: answers, backLink: "thinking-behaviours-attitudes" }) }}
 </dl>

--- a/server/views/components/summary/thinking-behaviours-attitudes/template.njk
+++ b/server/views/components/summary/thinking-behaviours-attitudes/template.njk
@@ -1,14 +1,14 @@
 {% import "components/summary/macro.njk" as summary %}
 
-{%- macro renderRiskSexualHarmWarningText()-%}
+ {%- macro renderRiskSexualHarmWarningText()-%}
           <div class="govuk-warning-text">
             <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
             <strong class="govuk-warning-text__text">
               <span class="govuk-visually-hidden">Warning</span>
               [subject] does not have any current or previous sexual or sexually motivated offences
             </strong>
-          </div>
-{%- endmacro -%}
+          </div>       
+{%- endmacro -%} 
 
 <dl class="govuk-summary-list">
   {% set fieldCodes = [

--- a/server/views/forms/sbna-poc/thinking-behaviours-attitudes-summary-analysis-complete.njk
+++ b/server/views/forms/sbna-poc/thinking-behaviours-attitudes-summary-analysis-complete.njk
@@ -9,7 +9,7 @@
 {% block analysisPanel %} 
   {{ renderAnalysisSummary(
     "thinking-behaviours-attitudes",
-    "thinking-behaviours-attitudes-analysis#practitioner-analysis",
+    "thinking-behaviours-attitudes-summary-analysis#practitioner-analysis",
     options.allFields
   ) }}
 {% endblock %}

--- a/server/views/forms/sbna-poc/thinking-behaviours-attitudes-summary-analysis-complete.njk
+++ b/server/views/forms/sbna-poc/thinking-behaviours-attitudes-summary-analysis-complete.njk
@@ -1,0 +1,15 @@
+{% extends "../summary.njk" %}
+{% from "components/analysis/macro.njk" import renderAnalysisSummary %}
+{% from "components/summary/thinking-behaviours-attitudes/macro.njk" import renderSummaryFor %}
+
+{% block summaryPanel %}
+  {{ renderSummaryFor(options.allFields, answers) }}
+{% endblock %}
+
+{% block analysisPanel %} 
+  {{ renderAnalysisSummary(
+    "thinking-behaviours-attitudes",
+    "thinking-behaviours-attitudes-analysis#practitioner-analysis",
+    options.allFields
+  ) }}
+{% endblock %}

--- a/server/views/forms/sbna-poc/thinking-behaviours-attitudes-summary-analysis.njk
+++ b/server/views/forms/sbna-poc/thinking-behaviours-attitudes-summary-analysis.njk
@@ -1,0 +1,33 @@
+{% extends "../summary.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "components/question/macro.njk" import renderQuestion %}
+{% from "components/summary/thinking-behaviours-attitudes/macro.njk" import renderSummaryFor %}
+
+{% block summaryPanel %}
+  {{ renderSummaryFor(options.allFields, answers) }}
+{% endblock %}
+
+{% block analysisPanel %}
+  <form id="form" method="post" action="{{ action }}#practitioner-analysis">
+    <input type="hidden" name="x-csrf-token" value="{{ getCsrf() }}">
+    {% for field in (form.fields | removeSectionCompleteFields) %}
+      {{ renderQuestion(options.fields[field], errors) }}
+    {% endfor %}
+
+    <div class="questiongroup-action-buttons">
+      {{ govukButton({
+        text: buttonText | default("Mark as complete"),
+        classes: "govuk-!-margin-bottom-3 govuk-!-margin-right-1"
+      }) }}
+
+      {% set saveDraftAction = action + "?action=saveDraft" %}
+      {{ govukButton({
+        text: "Save as draft",
+        classes: 'govuk-!-margin-bottom-3 govuk-!-margin-right-1 govuk-button--secondary',
+        attributes: {
+          "formaction": saveDraftAction
+        }
+      }) }}
+    </div>
+  </form>
+{% endblock %}


### PR DESCRIPTION
In summary page '[subject]' is being pulled through and not the PoP's name. Probably due to it being hard coded in the template file. 

Here are a couple of ways i tried to fix it:

From debugging to render the hint message you can use `option.hint.html `
e.g
`<span class="summary__answer">{{ option.hint }}</span> `
or
`<span class="summary__answer">{{ option.hint.html }}</span>`

Or create a macro specifically for the warning text 
```
{%- macro renderWarningText(fields, answers) -%}
 <ul class="govuk-list">
   {% for option in fields["thinking_behaviours_attitudes_risk_sexual_harm"].options %}
       {% if option.checked %}
       <li class="summary-details-list">
         <span class="summary__answer">{{ option.hint }}</span>
       </li>
     {% endif %}
   {% endfor %}
 </ul>
{%- endmacro -%} 
```

i looked into importing the warming text component in the fields file so it could be used in the template

`{% from "fields/thinking-behaviours-attitudes.ts" import sexualHarmWarningText %} `

<img width="980" alt="Screenshot 2024-01-31 at 09 08 26" src="https://github.com/ministryofjustice/hmpps-strengths-based-needs-assessments-ui/assets/90312885/59525584-7f5d-4988-80f0-5fa8458356a7">


If there is a way to fix this, lmk!

