### PR TITLE
ARN-2066 - Fix routing and validation logic for employment and education

### DIFF
--- a/app/common/controllers/saveAndContinue.ts
+++ b/app/common/controllers/saveAndContinue.ts
@@ -36,7 +36,11 @@ class SaveAndContinueController extends BaseController {
             : dependentValue === field.dependent.value)
         )
       })
-      .reduce((updatedAnswers, [key, field]) => ({ ...updatedAnswers, [field.code]: req.form.values[key] }), {})
+      .reduce((updatedAnswers, [key, field]) => {
+        return field.id
+          ? { ...updatedAnswers, [field.id]: req.form.values[key], [field.code]: req.form.values[key] }
+          : { ...updatedAnswers, [field.code]: req.form.values[key] }
+      }, {})
 
     return super.process(req, res, next)
   }

--- a/app/sbna-poc/v1_0__initial-form/controllers/saveAndContinueController.utils.ts
+++ b/app/sbna-poc/v1_0__initial-form/controllers/saveAndContinueController.utils.ts
@@ -94,7 +94,7 @@ export const getAnswersToAdd = (
   return Object.values(fields)
     .filter(it => dependencyMet(it, allFields, answers))
     .reduce((answerDtos, it) => {
-      const thisAnswer = answers[it.code]
+      const thisAnswer = answers[it.id || it.code]
 
       if (it) {
         switch (it.type) {

--- a/server/views/components/question/template.njk
+++ b/server/views/components/question/template.njk
@@ -8,7 +8,7 @@
 {%- from "govuk/components/button/macro.njk" import govukButton -%}
 {%- from "govuk/components/character-count/macro.njk" import govukCharacterCount -%}
 
-{% set errorMessageText = errors[question.code].message %}
+{% set errorMessageText = errors[question.id].message %}
 {% if errorMessageText %}
   {% set errorMessage = { text: errorMessageText } %}
 {% endif %}


### PR DESCRIPTION
Fixes some weirdness with validation/routing for questions with shared codes.
- Maintain values keyed by ID for use in validation, this is used as the key for validation errors
- Update `getAnswersToAdd` to first attempt to source an answer by ID (local), falling back to the answer by code (persisted)