### PR TITLE
Separate drug use completion names

### DIFF
--- a/app/form/v1_0/config/sections.ts
+++ b/app/form/v1_0/config/sections.ts
@@ -40,7 +40,7 @@ export default {
   drugsUse: {
     title: 'Drug use (new)',
     code: 'temp-drug-use', // TODO: Remove 'temp'
-    sectionCompleteField: 'drugs_use_section_complete',
+    sectionCompleteField: 'temp_drug_use_section_complete', // TODO: Remove 'temp'
   },
   healthWellbeing: {
     title: 'Health and wellbeing',

--- a/app/form/v1_0/fields/drug-use/drug-use.ts
+++ b/app/form/v1_0/fields/drug-use/drug-use.ts
@@ -2,9 +2,10 @@ import FormWizard from 'hmpo-form-wizard'
 import { FieldType, ValidationType } from '../../../../../server/@types/hmpo-form-wizard/enums'
 import { utils } from '../common'
 
+// TODO: remove 'temp' when ready
 const drugUse: FormWizard.Field = {
   text: 'Has [subject] ever misused drugs?',
-  code: 'drug_use',
+  code: 'temp_drug_use', // TODO remove 'temp' when ready
   type: FieldType.Radio,
   hint: {
     text: 'This includes illegal and prescription drugs.',


### PR DESCRIPTION
Makes section and section completion names more different to the pre-existing drug use section to aid debugging whilst both exist in the codebase.