### PR TITLE
ARN-2804 Stops focus leaving the modal in Offence Analysis

### DIFF
--- a/server/views/components/modal.njk
+++ b/server/views/components/modal.njk
@@ -14,7 +14,7 @@
             },
             classes: 'govuk-button--warning'
           }) }}
-          <div role="button" class="govuk-link gem-c-modal-dialogue__custom-close-button">Cancel</div>
+          <button class="govuk-link gem-c-modal-dialogue__custom-close-button">Cancel</button>
         </div>
       </div>
     </dialog>


### PR DESCRIPTION
Changes the div to a button so focus can't leave the modal. I have no idea why this works.

In principle it should be easy to add a new cypress test in `offence-analysis-victim-details.cy.ts` for this fix along these lines:

```typescript
  it('cannot escape modal', () => {
    cy.getCollectionEntry('victim', 1).as('firstVictim')
    cy.get('@firstVictim').find('.govuk-link').contains('Delete').click()
    cy.get('@firstVictim').find('.gem-c-modal-dialogue').should('be.visible')
    cy.press(Cypress.Keyboard.Keys.TAB)
    cy.get('@firstVictim').find('button[type="submit"].govuk-button--warning').should('have.focus')
    cy.press(Cypress.Keyboard.Keys.TAB)
    cy.get('@firstVictim').find('.gem-c-modal-dialogue__custom-close-button').should('have.focus')
    cy.press(Cypress.Keyboard.Keys.TAB)
    cy.get('@firstVictim').find('button[type="submit"].govuk-button--warning').should('have.focus')
  })
```

but the focus behaviour seems to work differently in Cypress to in my local browser :/