### PR TITLE
ARN-2795 Adds aria-required to single fields as well as fields which have a list of options

### DIFF
--- a/app/utils/field.utils.ts
+++ b/app/utils/field.utils.ts
@@ -233,6 +233,8 @@ export const dependencyMet = (field: FormWizard.Field, answers: FormWizard.Answe
 
 export const isPractitionerAnalysisField = (field: string) => field.includes('_practitioner_analysis_')
 
+// Adds aria-required attribute to fields that have a Required validator.
+// Either adds it to the field itself or to each option in a checkbox/radio field.
 export const addAriaRequiredAttributeToRequiredFields = () => (field: FormWizard.Field) => {
   // Only add aria-required if the field has a required validator
   const hasRequiredValidator = field.validate?.some(v => 'type' in v && v?.type === ValidationType.Required) || false
@@ -241,16 +243,15 @@ export const addAriaRequiredAttributeToRequiredFields = () => (field: FormWizard
 
   const modifiedField = { ...field }
 
-  modifiedField.options = (field.options || []).map(option => {
-    if (option.kind === 'divider' || option.value === 'NONE') return option
-    return {
-      ...option,
-      attributes: {
-        ...(option.attributes || {}),
-        'aria-required': true,
-      },
-    }
-  })
+  if (modifiedField.options) {
+    modifiedField.options = modifiedField.options.map(option =>
+      option.kind === 'divider' || option.value === 'NONE'
+        ? option
+        : { ...option, attributes: { ...(option.attributes || {}), 'aria-required': true } },
+    )
+  } else {
+    modifiedField.attributes = { ...(field.attributes || {}), 'aria-required': true }
+  }
 
   return modifiedField
 }

--- a/cypress/e2e/v1.0/pages/offence-analysis/questions/descriptionOfTheOffence.ts
+++ b/cypress/e2e/v1.0/pages/offence-analysis/questions/descriptionOfTheOffence.ts
@@ -6,6 +6,7 @@ export default (stepUrl: string, summaryPage: string, positionNumber: number) =>
   describe(question, () => {
     it(`displays and validates the question`, () => {
       cy.getQuestion(question).isQuestionNumber(positionNumber).hasHint(null).hasLimit(config.characterLimit.c4000)
+      cy.getQuestion(question).get('textarea').should('have.attr', 'aria-required')
       cy.saveAndContinue()
       cy.assertStepUrlIs(stepUrl)
       cy.getQuestion(question).hasValidationError('Enter details').enterText('some text')

--- a/server/@types/hmpo-form-wizard/index.d.ts
+++ b/server/@types/hmpo-form-wizard/index.d.ts
@@ -13,7 +13,6 @@ declare module 'hmpo-form-wizard' {
     interface FormOptions {
       allFields: { [key: string]: Field }
       journeyName: string
-      section: string
       sectionProgressRules: Array<SectionProgressRule>
       fields: Fields
       steps: RenderedSteps
@@ -189,6 +188,7 @@ declare module 'hmpo-form-wizard' {
       labelClasses?: string
       formGroupClasses?: string
       classes?: string
+      attributes?: Record<string, unknown>
       summary?: {
         text?: string
         displayFn?: (value: string) => string


### PR DESCRIPTION
The first PR for this issue only added aria-required to checkboxes and radio buttons. This PR also adds it to fields which are single-entry like input boxes and text areas.