### PR TITLE
ARN-2795 Adds aria-required to step collections 

### DIFF
--- a/app/controllers/baseCollectionController.ts
+++ b/app/controllers/baseCollectionController.ts
@@ -6,7 +6,13 @@ import BaseController from './baseController'
 import { createAnswerDTOs, flattenAnswers } from './saveAndContinue.utils'
 import { SessionData, userDetailsFromSession } from '../../server/services/strengthsBasedNeedsService'
 import { HandoverSubject } from '../../server/services/arnsHandoverService'
-import { compileConditionalFields, fieldsById, withPlaceholdersFrom, withValuesFrom } from '../utils/field.utils'
+import {
+  addAriaRequiredAttributeToRequiredFields,
+  compileConditionalFields,
+  fieldsById,
+  withPlaceholdersFrom,
+  withValuesFrom,
+} from '../utils/field.utils'
 import { FieldType } from '../../server/@types/hmpo-form-wizard/enums'
 import { FieldDependencyTreeBuilder } from '../utils/fieldDependencyTreeBuilder'
 import { Progress } from './saveAndContinueController'
@@ -173,7 +179,8 @@ abstract class BaseCollectionController extends BaseController {
       const fieldsWithReplacements = fieldsWithMappedAnswers.map(
         withPlaceholdersFrom(res.locals.placeholderValues || {}),
       )
-      const fieldsWithRenderedConditionals = compileConditionalFields(fieldsWithReplacements, {
+      const fieldsWithRequiredAttributes = fieldsWithReplacements.map(addAriaRequiredAttributeToRequiredFields())
+      const fieldsWithRenderedConditionals = compileConditionalFields(fieldsWithRequiredAttributes, {
         action: res.locals.action,
         errors: res.locals.errors,
       })

--- a/app/utils/field.utils.test.ts
+++ b/app/utils/field.utils.test.ts
@@ -245,7 +245,7 @@ describe('field.utils', () => {
       const field = {
         text: 'Sample text',
         code: 'sample_code',
-        type: 'radio',
+        type: 'RADIO',
         validate: [{ type: ValidationType.Required, message: 'Validation error message' }],
         options: [
           { text: 'option0', kind: 'option', value: 'SETTLED' } as FormWizard.Field.Option,
@@ -269,7 +269,7 @@ describe('field.utils', () => {
       const field = {
         text: 'Sample text',
         code: 'sample_code',
-        type: 'radio',
+        type: 'RADIO',
         validate: [{ type: ValidationType.Required, message: 'Validation error message' }],
         options: [
           {
@@ -293,7 +293,7 @@ describe('field.utils', () => {
       const field = {
         text: 'Sample text',
         code: 'sample_code',
-        type: 'radio',
+        type: 'RADIO',
         validate: [{ type: ValidationType.Required, message: 'Validation error message' }],
         options: [{ text: 'option0', kind: 'option', value: 'SETTLED' } as FormWizard.Field.Option],
       }
@@ -309,7 +309,7 @@ describe('field.utils', () => {
       const field = {
         text: 'Sample text',
         code: 'sample_code',
-        type: 'radio',
+        type: 'RADIO',
         options: [{ text: 'option0', kind: 'option', value: 'SETTLED' } as FormWizard.Field.Option],
       }
 

--- a/app/utils/field.utils.ts
+++ b/app/utils/field.utils.ts
@@ -243,7 +243,7 @@ export const addAriaRequiredAttributeToRequiredFields = () => (field: FormWizard
 
   const modifiedField = { ...field }
 
-  if ((field.type === "RADIO" || field.type === "CHECKBOX") && modifiedField.options) {
+  if ((field.type === 'RADIO' || field.type === 'CHECKBOX') && modifiedField.options) {
     modifiedField.options = modifiedField.options.map(option =>
       option.kind === 'divider'
         ? option

--- a/app/utils/field.utils.ts
+++ b/app/utils/field.utils.ts
@@ -243,7 +243,7 @@ export const addAriaRequiredAttributeToRequiredFields = () => (field: FormWizard
 
   const modifiedField = { ...field }
 
-  if (modifiedField.options) {
+  if ((field.type === "RADIO" || field.type === "CHECKBOX") && modifiedField.options) {
     modifiedField.options = modifiedField.options.map(option =>
       option.kind === 'divider'
         ? option

--- a/cypress/e2e/v1.0/pages/offence-analysis/questions/victim/victimRaceOrEthnicity.ts
+++ b/cypress/e2e/v1.0/pages/offence-analysis/questions/victim/victimRaceOrEthnicity.ts
@@ -27,6 +27,12 @@ const testCreate = (createUrl: string, editUrl: string, positionNumber: number) 
       cy.assertStepUrlIs(createUrl)
 
       cy.getQuestion(question).isQuestionNumber(positionNumber)
+      cy.getQuestion(question)
+        .isQuestionNumber(positionNumber)
+        .get('select')
+        .first()
+        .should('have.attr', 'aria-required')
+
       cy.saveAndContinue()
       cy.getQuestion(question).hasValidationError("Select the victim's ethnicity")
       cy.checkAccessibility()

--- a/cypress/e2e/v1.0/pages/offence-analysis/questions/victim/victimRelationship.ts
+++ b/cypress/e2e/v1.0/pages/offence-analysis/questions/victim/victimRelationship.ts
@@ -16,6 +16,12 @@ const testCreate = (createUrl: string, editUrl: string, positionNumber: number) 
       cy.assertStepUrlIs(createUrl)
 
       cy.getQuestion(question).isQuestionNumber(positionNumber).hasHint(null).hasRadios(options)
+      cy.getQuestion(question)
+        .isQuestionNumber(positionNumber)
+        .get('.govuk-radios__input')
+        .first()
+        .should('have.attr', 'aria-required')
+
       cy.saveAndContinue()
       cy.getQuestion(question).hasValidationError('Select who the victim is')
       cy.checkAccessibility()


### PR DESCRIPTION
Makes sure to add the aria-required attribute to required fields used in collections creation screens and make sure to only add the attribute to <options> under radio and checkbox input types, not SELECT.