### PR TITLE
ACE-149 Change date formatter util to have no zero padding

### DIFF
--- a/app/utils/fieldDependencyTreeBuilder.test.ts
+++ b/app/utils/fieldDependencyTreeBuilder.test.ts
@@ -283,7 +283,7 @@ describe('app/utils/fieldDependencyTreeBuilder', () => {
     it('should return date field answer', () => {
       textField.type = FieldType.Date
       const sut = builderWithAnswer('q2', '1970-01-01')
-      const expected: FieldAnswer[] = [{ text: '01 January 1970', value: '01 January 1970', nestedFields: [] }]
+      const expected: FieldAnswer[] = [{ text: '1 January 1970', value: '1 January 1970', nestedFields: [] }]
       expect(sut.getFieldAnswers(textField)).toEqual(expected)
     })
 

--- a/app/utils/formatters.test.ts
+++ b/app/utils/formatters.test.ts
@@ -34,7 +34,7 @@ describe('unescape', () => {
 
 describe('formatDateForDisplay', () => {
   it('returns the data in the format', () => {
-    expect(formatDateForDisplay('2023-08-02')).toEqual('02 August 2023')
+    expect(formatDateForDisplay('2023-08-02')).toEqual('2 August 2023')
   })
 
   it('returns null when passed a null/undefined value', () => {

--- a/app/utils/formatters.ts
+++ b/app/utils/formatters.ts
@@ -26,13 +26,13 @@ export const unescape = (input: string) =>
     .replace(/&#x5C;/g, '\\')
     .replace(/&#96;/g, '`')
 
-export const formatDateForDisplay = (value: string): string => {
+export const formatDateForDisplay = (value: string, dateFormat = 'd MMMM y'): string => {
   if (!value) {
     return null
   }
 
   const date = DateTime.fromISO(value)
-  return date.isValid ? date.toFormat('d MMMM y') : null
+  return date.isValid ? date.toFormat(dateFormat) : null
 }
 
 export const ordinalWordFromNumber = (n: number): string => {

--- a/app/utils/formatters.ts
+++ b/app/utils/formatters.ts
@@ -26,7 +26,12 @@ export const unescape = (input: string) =>
     .replace(/&#x5C;/g, '\\')
     .replace(/&#96;/g, '`')
 
-export const formatDateForDisplay = (value: string, dateFormat = 'd MMMM y'): string => {
+export enum DateFormats {
+  DEFAULT = 'd MMMM y',
+  JUST_YEAR = 'yyyy',
+}
+
+export const formatDateForDisplay = (value: string, dateFormat: DateFormats = DateFormats.DEFAULT): string => {
   if (!value) {
     return null
   }

--- a/app/utils/formatters.ts
+++ b/app/utils/formatters.ts
@@ -32,7 +32,7 @@ export const formatDateForDisplay = (value: string): string => {
   }
 
   const date = DateTime.fromISO(value)
-  return date.isValid ? date.toFormat('dd MMMM y') : null
+  return date.isValid ? date.toFormat('d MMMM y') : null
 }
 
 export const ordinalWordFromNumber = (n: number): string => {

--- a/cypress/e2e/v1.0/pages/accommodation/questions/accommodationStatus.ts
+++ b/cypress/e2e/v1.0/pages/accommodation/questions/accommodationStatus.ts
@@ -224,7 +224,7 @@ export default (stepUrl: string, summaryPage: string, positionNumber: number) =>
           cy.visitStep(summaryPage)
           cy.getSummary(question)
             .getAnswer(options.temporary)
-            .hasSecondaryAnswer(typeOfTemporaryAccommodation, 'Expected end date: 01 January 2050')
+            .hasSecondaryAnswer(typeOfTemporaryAccommodation, 'Expected end date: 1 January 2050')
           cy.checkAccessibility()
           cy.getSummary(question).clickChange()
           cy.assertStepUrlIs(stepUrl)

--- a/cypress/e2e/v1.0/view-historic.cy.ts
+++ b/cypress/e2e/v1.0/view-historic.cy.ts
@@ -10,13 +10,11 @@ describe('view-historic mode from previous versions page', () => {
     cy.get('@view-link').invoke('attr', 'target', '_self').click()
 
     const today = new Date()
-    today.setDate(today.getDate() - 1)
-
-    const day = String(today.getDate()).padStart(2, '0')
-    const month = today.toLocaleDateString('en-GB', { month: 'long' })
-    const year = today.getFullYear()
-
-    const expectedDate = `${day} ${month} ${year}`
+    const expectedDate = new Date(today.setDate(today.getDate() - 1)).toLocaleDateString('en-GB', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    })
 
     cy.get('.moj-alert--information').contains(`This version is from ${expectedDate}`)
     cy.contains('.govuk-button', 'Return to OASys').should('not.exist')


### PR DESCRIPTION
### Change `formatDateForDisplay` to have no zero padding.

**NOTE:** This change is across the project (applies to all dates using `formatDateForDisplay`)

**Example (previous-versions page):**
<img width="1203" height="764" alt="Screenshot 2025-08-08 at 11 08 59" src="https://github.com/user-attachments/assets/daeb75c3-0918-406a-a446-5e169c161580" />
<img width="1222" height="566" alt="Screenshot 2025-08-08 at 11 09 11" src="https://github.com/user-attachments/assets/02ab3ab8-74a6-4df9-b7a5-59f717a11eab" />

**Example (accommodation-summary page):**
<img width="986" height="592" alt="Screenshot 2025-08-08 at 11 23 18" src="https://github.com/user-attachments/assets/c39c220b-23c2-400e-868a-614922153b7b" />
