### PR TITLE
Fix break spacing

### DIFF
--- a/server/views/partials/offenderDetails.njk
+++ b/server/views/partials/offenderDetails.njk
@@ -63,8 +63,8 @@
   <div id="assessment-info" class="govuk-visually-hidden" data-assessment-id="{{ sessionData.assessmentId }}"></div>
 </div>
 {% if isPrivacyScreen %}
-  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible form-header_hr govuk-grid-column-full govuk-!-margin-top-0 govuk-!-margin-bottom-3">
+  <hr class="govuk-section-break govuk-section-break--visible form-header__hr govuk-!-margin-bottom-3">
   <a class="govuk-back-link govuk-!-margin-bottom-5 govuk-!-margin-top-0" href="{{ oasysUrl }}">Back</a>
 {% else %}
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible form-header_hr govuk-grid-column-full">
+  <hr class="govuk-section-break govuk-section-break--visible form-header__hr">
 {% endif %}


### PR DESCRIPTION
Brought back the changes made to break line (ACE-149 Extract modes into config #874)

Before:
<img width="982" height="843" alt="Screenshot 2025-08-11 at 10 13 46" src="https://github.com/user-attachments/assets/e636cc21-a957-466c-bb0e-19178cc7a285" />

After:
<img width="982" height="822" alt="Screenshot 2025-08-11 at 10 14 03" src="https://github.com/user-attachments/assets/ad8b5342-f50c-4ce3-9c6e-017c4dff7c60" />
