### PR TITLE
Enable training session launcher flow for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To start it, run:
 
 `make up`
 
-The entry point for the service is http://localhost:7072
+The entry point for the service is the [Training Launcher](http://localhost:7072/training-session-launcher)
 
 To update containers
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -11,6 +11,10 @@ services:
     ports:
       - "8080:8080"
 
+  aap-ui:
+    ports:
+      - "7072:3000"
+
   san-ui:
     depends_on:
       - forward-proxy
@@ -20,16 +24,20 @@ services:
       - "3000:3000"
 
   arns-handover:
+    volumes:
+      - ./docker/handover/application-local.yml:/app/resources/application-local.yml
+    environment:
+      SPRING_CONFIG_ADDITIONAL_LOCATION: file:/app/resources/application-local.yml
     ports:
       - "7070:7070"
 
   hmpps-auth:
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/9090'"]
+      interval: 5s
+      retries: 60
     ports:
       - "9090:9090"
-
-  aap-ui:
-    ports:
-      - "7072:3000"
 
   forward-proxy:
     image: nginx:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,9 @@ services:
       TIER_API_URL: http://localhost:8083
       INTERVENTIONS_API_URL: http://localhost:8084
       SAN_EXTERNAL_URL: http://localhost:3000
+      SAN_URL: http://localhost:3000
+      MPOP_URL: "http://ui:3000/sign-in"
+      SERVICE_NOW_FORM_URL: "#service-now-link"
       TRAINING_SESSION_LAUNCHER_ENABLED: "true"
 
   coordinator-api:

--- a/docker/auth_db/V1000_0__aap_clients.sql
+++ b/docker/auth_db/V1000_0__aap_clients.sql
@@ -1,12 +1,31 @@
--- Add auth client (auth_code flow) for AAP-UI. Client secret is clientsecret
-INSERT INTO oauth_client_details (client_id, access_token_validity, additional_information, authorities, authorized_grant_types, autoapprove, client_secret, refresh_token_validity, resource_ids, scope, web_server_redirect_uri)
-VALUES ('hmpps-arns-assessment-platform-ui', 3600, '{}', null, 'authorization_code,refresh_token', 'read,write', '$2a$10$lBwbziQlLfiCnn8Kj1PfMujEcLdsJYlYSNJvBRO638gCYTS9yN0xm', 43200, null, 'read,write', 'http://localhost:3000,http://localhost:3000/sign-in/callback,http://localhost:3000/sign-in/hmpps-auth/callback,http://localhost:7072,http://localhost:7072/sign-in/callback,http://localhost:7072/sign-in/hmpps-auth/callback');
+-- AAP-UI auth_code client for the new authorization server
+INSERT INTO oauth2_registered_client (id, client_id, client_id_issued_at, client_secret, client_secret_expires_at, client_name, client_authentication_methods, authorization_grant_types, redirect_uris, scopes, client_settings, token_settings, post_logout_redirect_uris)
+VALUES ('aap-ui-auth-code', 'hmpps-arns-assessment-platform-ui', current_timestamp,
+  '{bcrypt}$2a$10$lBwbziQlLfiCnn8Kj1PfMujEcLdsJYlYSNJvBRO638gCYTS9yN0xm', null,
+  'hmpps-arns-assessment-platform-ui',
+  'client_secret_basic', 'authorization_code,refresh_token',
+  'http://localhost:3000,http://localhost:3000/sign-in/callback,http://localhost:3000/sign-in/hmpps-auth/callback,http://localhost:7072,http://localhost:7072/sign-in/callback,http://localhost:7072/sign-in/hmpps-auth/callback',
+  'read,write',
+  '{"@class":"java.util.Collections$UnmodifiableMap","settings.client.require-proof-key":false,"settings.client.require-authorization-consent":false}',
+  '{"@class":"java.util.Collections$UnmodifiableMap","settings.token.reuse-refresh-tokens":true,"settings.token.id-token-signature-algorithm":["org.springframework.security.oauth2.jose.jws.SignatureAlgorithm","RS256"],"settings.token.access-token-time-to-live":["java.time.Duration",3600.000000000],"settings.token.access-token-format":{"@class":"org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat","value":"self-contained"},"settings.token.refresh-token-time-to-live":["java.time.Duration",43200.000000000]}',
+  null);
 
--- Add system client (S2S calls) for AAP-UI with ARNS roles. Client secret is clientsecret
-INSERT INTO oauth_client_details (client_id, access_token_validity, additional_information, authorities, authorized_grant_types, autoapprove, client_secret, refresh_token_validity, resource_ids, scope, web_server_redirect_uri)
-VALUES ('hmpps-arns-assessment-platform-ui-system', 1200, '{}', 'ROLE_AAP__FRONTEND_RW,ROLE_STRENGTHS_AND_NEEDS_OASYS', 'client_credentials', 'read,write', '$2a$10$lBwbziQlLfiCnn8Kj1PfMujEcLdsJYlYSNJvBRO638gCYTS9yN0xm', 43200, null, 'read,write', null);
+-- AAP-UI system client (client_credentials) for the new authorization server
+INSERT INTO oauth2_registered_client (id, client_id, client_id_issued_at, client_secret, client_secret_expires_at, client_name, client_authentication_methods, authorization_grant_types, redirect_uris, scopes, client_settings, token_settings, post_logout_redirect_uris)
+VALUES ('aap-ui-system', 'hmpps-arns-assessment-platform-ui-system', current_timestamp,
+  '{bcrypt}$2a$10$lBwbziQlLfiCnn8Kj1PfMujEcLdsJYlYSNJvBRO638gCYTS9yN0xm', null,
+  'hmpps-arns-assessment-platform-ui-system',
+  'client_secret_basic', 'client_credentials',
+  null, 'read,write',
+  '{"@class":"java.util.Collections$UnmodifiableMap","settings.client.require-proof-key":false,"settings.client.require-authorization-consent":false}',
+  '{"@class":"java.util.Collections$UnmodifiableMap","settings.token.reuse-refresh-tokens":true,"settings.token.id-token-signature-algorithm":["org.springframework.security.oauth2.jose.jws.SignatureAlgorithm","RS256"],"settings.token.access-token-time-to-live":["java.time.Duration",1200.000000000],"settings.token.access-token-format":{"@class":"org.springframework.security.oauth2.server.authorization.settings.OAuth2TokenFormat","value":"self-contained"},"settings.token.refresh-token-time-to-live":["java.time.Duration",600.000000000]}',
+  null);
 
--- Update coordinator API client with required roles for local dev
-UPDATE oauth_client_details
+-- Authorities/roles for the system client (replaces old 'authorities' column)
+INSERT INTO oauth2_authorization_consent (registered_client_id, principal_name, authorities)
+VALUES ('aap-ui-system', 'hmpps-arns-assessment-platform-ui-system', 'ROLE_AAP__FRONTEND_RW,ROLE_STRENGTHS_AND_NEEDS_OASYS');
+
+-- Authorities/roles for the coordinator API client (equivalent of the UPDATE above)
+UPDATE oauth2_authorization_consent
 SET authorities = 'ROLE_STRENGTHS_AND_NEEDS_OASYS,ROLE_STRENGTHS_AND_NEEDS_READ,ROLE_STRENGTHS_AND_NEEDS_WRITE,ROLE_AAP__COORDINATOR_RW'
-WHERE client_id = 'hmpps-assess-risks-and-needs-oastub-ui';
+WHERE principal_name = 'hmpps-assess-risks-and-needs-oastub-ui';

--- a/docker/handover/application-local.yml
+++ b/docker/handover/application-local.yml
@@ -1,0 +1,12 @@
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuers:
+            - issuer-name: "HMPPS Handover"
+              jwk-set-uri: http://arns-handover:7070/oauth2/jwks
+              issuer-uri: http://arns-handover:7070
+            - issuer-name: "HMPPS Auth"
+              jwk-set-uri: http://hmpps-auth:9090/auth/.well-known/jwks.json
+              issuer-uri: http://localhost:9090/auth/issuer

--- a/server/app.ts
+++ b/server/app.ts
@@ -17,6 +17,7 @@ import setUpWebSession from './middleware/setUpWebSession'
 import routes from './routes'
 import authorisationMiddleware from './middleware/authorisationMiddleware'
 import handoverContextMiddleware from './middleware/handoverContextMiddleware'
+import App from '../app'
 
 export default function createApp(): express.Application {
   const app = express()
@@ -25,8 +26,11 @@ export default function createApp(): express.Application {
   app.set('trust proxy', true)
   app.set('port', process.env.PORT || 3000)
 
+  const formApp = new App()
+
   app.use(metricsMiddleware)
   app.use(setUpHealthChecks())
+  app.use('/config', formApp.formConfigRouter)
   app.use(setUpWebSecurity())
   app.use(setUpWebSession())
   app.use(setUpWebRequestParsing())
@@ -39,7 +43,7 @@ export default function createApp(): express.Application {
   // app.use(setUpCsrf())
   // app.use(setUpCurrentUser())
 
-  app.use(routes())
+  app.use(routes(formApp))
 
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler())

--- a/server/app.ts
+++ b/server/app.ts
@@ -30,8 +30,8 @@ export default function createApp(): express.Application {
 
   app.use(metricsMiddleware)
   app.use(setUpHealthChecks())
-  app.use('/config', formApp.formConfigRouter)
   app.use(setUpWebSecurity())
+  app.use('/config', formApp.formConfigRouter)
   app.use(setUpWebSession())
   app.use(setUpWebRequestParsing())
   app.use(setUpStaticResources())

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,14 +7,12 @@ import config from '../config'
 import { validateMode } from '../middleware/validateMode'
 import viewHistoricalVersions from '../../app/controllers/viewHistoricalVersions'
 
-export default function routes(): Router {
+export default function routes(app: App): Router {
   const router = Router()
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
-  const app = new App()
   router.use('/form/:mode/:uuid', validateMode, app.getFormWizardRouter())
   router.use(App.errorHandler)
-  router.use('/config', app.formConfigRouter)
   router.use('/start', startController) // viewing or editing the latest version
   router.use('/view-historical-versions/:assessmentVersionId', viewHistoricalVersions) // for viewing previous versions
 

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -8,6 +8,7 @@ import errorHandler from '../../errorHandler'
 import * as auth from '../../authentication/auth'
 import { Services } from '../../services'
 import { Gender } from '../../@types/hmpo-form-wizard/enums'
+import App from '../../../app'
 
 export const user = {
   firstName: 'first',
@@ -52,7 +53,7 @@ function appSetup(userSupplier: () => Express.User, additionalRoutes: Router[]):
   })
   app.use(express.json())
   app.use(express.urlencoded({ extended: true }))
-  app.use(routes())
+  app.use(routes(new App()))
   additionalRoutes.forEach(it => app.use(it))
   app.use((req, res, next) => next(createError(404, 'Not found')))
   app.use(errorHandler())


### PR DESCRIPTION
- Register AAP-UI OAuth2 clients in hmpps-auth so the training session launcher can authenticate and create handover sessions
- Move `/config` route before authentication middleware so SAN API can fetch form config without requiring a token
- Fix JWT issuer mismatch between hmpps-auth and handover service by mounting a local config override that splits `issuer-uri` from `jwk-set-uri`
- Fix hmpps-auth Docker healthcheck (curl removed from latest image, replaced with bash TCP check)
- Expose aap-ui on port 7072 and add required environment variables